### PR TITLE
Snakefile: remove AUGUR_RECURSION_LIMIT

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -262,7 +262,7 @@ rule clades:
             --output {output.clade_data}
         """
 
-def node_data_files(wildcards):    
+def node_data_files(wildcards):
     patterns = [
         "results/{build}/branch_lengths.json",
         "results/{build}/nt_muts.json",
@@ -304,7 +304,6 @@ rule export:
         auspice_json = "auspice/hbv_{build}.json"
     shell:
         """
-        export AUGUR_RECURSION_LIMIT=10000;
         augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata} \


### PR DESCRIPTION
The AUGUR_RECURSION_LIMIT is set to 10,000 by default since Augur 22.0.0.

The workflow is currently WIP so it's not as clear what's the minimum required Augur version. However, I would expect the workflow to be run with the latest version of Nextstrain tools.


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Test locally 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
